### PR TITLE
Add jsDelivr links

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,14 +81,20 @@ var LZUTF8 = require('lzutf8');
 
 Browser:
 ```html
+<script id="lzutf8" src="https://cdn.jsdelivr.net/npm/lzutf8/build/production/lzutf8.js"></script>
+<!-- or -->
 <script id="lzutf8" src="https://unpkg.com/lzutf8"></script>
 ```
 or the minified version:
 ```html
+<script id="lzutf8" src="https://cdn.jsdelivr.net/npm/lzutf8/build/production/lzutf8.min.js"></script>
+<!-- or -->
 <script id="lzutf8" src="https://unpkg.com/lzutf8/production/lzutf8.min.js"></script>
 ```
 to reference a particular version use the pattern, where `x.x.x` should be replaced with the exact version number (e.g. `0.4.6`):
 ```html
+<script id="lzutf8" src="https://cdn.jsdelivr.net/npm/lzutf8@x.x.x/build/production/lzutf8.min.js"></script>
+<!-- or -->
 <script id="lzutf8" src="https://unpkg.com/lzutf8@x.x.x/production/lzutf8.min.js"></script>
 ```
 


### PR DESCRIPTION
I added [jsDelivr CDN links](https://www.jsdelivr.com/package/npm/lzutf8) to your readme as an alternative to unpkg. jsDelivr is the fastest opensource CDN available and built specifically for production usage. It can serve any project from npm with zero config just like unpkg, but offers a larger network and better reliability. We also have detailed usage stats for project maintainers.