### PR TITLE
Added Worker type to Gruntfile type stub

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -4,6 +4,7 @@ module.exports = function (grunt) {
 	const banner = '/*!\n LZ-UTF8 v<%=pkg.version%>\n\n Copyright (c) 2021, Rotem Dan\n Released under the MIT license.\n\n Build date: <%= grunt.template.today("yyyy-mm-dd") %> \n\n Please report any issue at https://github.com/rotemdan/lzutf8.js/issues\n*/\n';
 	const dummyTypeDeclarations = `declare namespace LZUTF8 {
     type Buffer = any;
+	type Worker = any;
 
     namespace stream {
         type Transform = any;


### PR DESCRIPTION
This fixes the following tsc error:

node_modules/lzutf8/build/production/lzutf8.d.ts:41:27 - error TS2304: Cannot find name 'Worker'.

41         let globalWorker: Worker;